### PR TITLE
Issue #4: Implement better handling of trailing punctuation.

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,5 +1,5 @@
 var remark = require('remark');
-var wrap = require('./dist/index.js');
+var wrap = require('./src/index.js');
 
 var markdown = 'Hello, world!';
 var result = remark().use(wrap, {width: 5}).process(markdown);

--- a/example.js
+++ b/example.js
@@ -1,5 +1,5 @@
 var remark = require('remark');
-var wrap = require('./src/index.js');
+var wrap = require('./dist/index.js');
 
 var markdown = 'Hello, world!';
 var result = remark().use(wrap, {width: 5}).process(markdown);

--- a/src/__tests__/fixtures/indented-lists.expected.md
+++ b/src/__tests__/fixtures/indented-lists.expected.md
@@ -1,0 +1,14 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis ligula
+sem, porttitor id neque et, elementum venenatis mi.
+
+-   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis ligula
+    sem, porttitor id neque et, elementum venenatis mi.
+    -   Aliquam dui nibh, consectetur vel imperdiet a, ullamcorper id ligula.
+        Donec vulputate suscipit massa ac vulputate.
+    -   Aenean accumsan maximus risus, a mattis mauris ullamcorper sit amet.
+        Vivamus sit amet convallis massa. Integer vitae felis in lacus finibus
+        pretium quis sit amet dui.
+-   Quisque viverra porttitor libero, vitae venenatis augue. Pellentesque
+    odio velit, faucibus sit amet euismod ut, tempus sit amet quam.
+-   Donec pretium malesuada arcu quis efficitur. Sed eget lectus libero.
+    Suspendisse id ligula vitae justo convallis sodales non at magna.

--- a/src/__tests__/fixtures/indented-lists.fixture.md
+++ b/src/__tests__/fixtures/indented-lists.fixture.md
@@ -1,0 +1,6 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis ligula sem, porttitor id neque et, elementum venenatis mi.
+* Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis ligula sem, porttitor id neque et, elementum venenatis mi.
+    * Aliquam dui nibh, consectetur vel imperdiet a, ullamcorper id ligula. Donec vulputate suscipit massa ac vulputate.
+    * Aenean accumsan maximus risus, a mattis mauris ullamcorper sit amet. Vivamus sit amet convallis massa. Integer vitae felis in lacus finibus pretium quis sit amet dui.
+* Quisque viverra porttitor libero, vitae venenatis augue. Pellentesque odio velit, faucibus sit amet euismod ut, tempus sit amet quam.
+* Donec pretium malesuada arcu quis efficitur. Sed eget lectus libero. Suspendisse id ligula vitae justo convallis sodales non at magna.

--- a/src/__tests__/fixtures/long-links.expected.md
+++ b/src/__tests__/fixtures/long-links.expected.md
@@ -1,0 +1,2 @@
+Really long link [here](https://example.com/some/really/long/path/should/not/wrap).
+Foo bar baz.

--- a/src/__tests__/fixtures/long-links.fixture.md
+++ b/src/__tests__/fixtures/long-links.fixture.md
@@ -1,0 +1,1 @@
+Really long link [here](https://example.com/some/really/long/path/should/not/wrap). Foo bar baz.


### PR DESCRIPTION
- Update example.js to refer to correct index location.
- Update logic for handling trailing punctuation that immediately
  follows a non-text node, such as a link.
- Add test cases covering updated logic.
- All tests passing.


I don't think this totally fixes the original concerns with #4. I really only looked at trailing punctuation use case.